### PR TITLE
fix goodreads parsing

### DIFF
--- a/org-books.el
+++ b/org-books.el
@@ -295,9 +295,10 @@ Assumes it has one."
 Return a list of three items: title (string), author (string) and
 an alist of properties to be applied to the org entry. If the url
 is not supported, throw an error."
-  (let ((output 'no-match))
+  (let ((output 'no-match)
+        (url-host-string (url-host (url-generic-parse-url url))))
     (cl-dolist (pattern-fn-pair org-books-url-pattern-dispatches)
-      (when (s-matches? (car pattern-fn-pair) url)
+      (when (s-matches? (car pattern-fn-pair) url-host-string)
         (setq output (funcall (cdr pattern-fn-pair) url))
         (cl-return)))
     (if (eq output 'no-match)


### PR DESCRIPTION
Parsing a book from goodreads fails for me with ``<URL> not understood``

I used git bisect to identify https://github.com/goderich/org-books/commit/2dab7957e98bc0bf8e8aa024c594461ee4a7cb41 as the first bad commit and reverted a part of it which fixed it for me. 

I also tested LibraryThing with my version and it seems to work as well.

Unfortunately the unit tests are broken for me so I couldn't verify the functionality.

Feel free to close if inappropriate.

